### PR TITLE
Use unordered_map for input-internal mapping

### DIFF
--- a/src/Graph.h
+++ b/src/Graph.h
@@ -14,11 +14,11 @@
 #include <fstream> // file reading/writing
 #include <iomanip> // setw()
 #include <iostream> // cout, clog, cerr, etc.
-#include <map> // mapping node id's
 #include <string> // filenames etc.
 #include "omp.h" // openMP paralellization
 #include <queue> // BFS
 #include <stack> // DFS
+#include <unordered_map> // mapping node id's
 #include <vector> // node data structure
 using namespace std;
 
@@ -134,8 +134,8 @@ class Graph {
 
     // graph data, always consistent
     int maxn; // maximal number of nodes
-    map<nodeidtype, int> nodeMapping; // mapping of input node-identifiers to 0, .., n-1
-    map<int, nodeidtype> revMapping; // mapping 0, .., n-1 to input node-identifiers 
+    unordered_map<nodeidtype, int> nodeMapping; // mapping of input node-identifiers to 0, .., n-1
+    unordered_map<int, nodeidtype> revMapping; // mapping 0, .., n-1 to input node-identifiers
     vector< vector<int> > E; // list of out-neighbors of i 		
     vector< vector<int> > rE; // list of in-neighbors of i	
 


### PR DESCRIPTION
`unordered_map` is a hash table. Hash tables are _fast_; they have _O(1)_ insertion and access time. `map` is a balanced binary tree; these are slower with `log(N)` insertion and access times. The only downside of a hash table is that it _can_ take more space than a balanced binary tree, though it doesn't always.

I test this PR by putting `return 0` in `main.cpp`, like so:
```c++
    Graph G;
    if(!G.loadUndirected(argv[1]))
        return 1;

    return 0;
```

And then measure runtime on a dataset with 56,977,804 edges using `/usr/bin/time -v`.

The existing code has
```
User time (seconds): 92.25
Maximum resident set size (kbytes): 9907208
```
while the new code has
```
User time (seconds): 41.86
Maximum resident set size (kbytes): 8471668
```

So we see that using `unordered_map` gets the data loaded in less than half the time while using less space!

Note that the C++ STL hash table is generally a slow implementation since it uses buckets instead of linear probing. See for instance [this SO answer](https://stackoverflow.com/a/48412487/752843) and also [this performance comparison](https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html). Still, a 2x speed-up without any additional dependencies is pretty decent.