### PR TITLE
Make for loops type safe

### DIFF
--- a/include/teexgraph/details/GraphTemplated.hpp
+++ b/include/teexgraph/details/GraphTemplated.hpp
@@ -11,7 +11,7 @@ void printDistri(
     const Scope scope = Scope::FULL
 ) {
     std::vector<Number> intarray(n + 1, 0);
-    for(int i = 0; i < (signed)values.size(); i++) {
+    for(size_t i = 0; i < values.size(); i++) {
         if(inScope(i, scope)) {
             intarray[values[i]]++;
         }
@@ -25,11 +25,12 @@ template <typename Number>
 void printList(const std::vector<Number> & values) {
     long double total = 0;
     double count = 0;
-    Number minvalue = INT_MAX;
-    Number maxvalue = -1;
-    int mini = INT_MAX;
-    int maxi = -1;
-    for(int i = 0; i < (signed)values.size(); i++)
+    //NOTE: Fails if values.size()==0
+    Number minvalue = values.front();
+    Number maxvalue = values.front();
+    size_t mini = 0;
+    size_t maxi = 0;
+    for(size_t i = 0; i < values.size(); i++)
         if(values[i] > 0) {
             mini = std::min(i, mini);
             maxi = std::max(i, maxi);
@@ -89,7 +90,7 @@ void printFilteredNodeList(
     for(int i = 0; i < n; i++)
         if(targetfilter[i] == targetvalue) {
             std::cout << revMapNode(i);
-            for(int j = 0; j < (signed)values.size(); j++)
+            for(size_t j = 0; j < values.size(); j++)
                 std::cout << '\t' << values[j][i]; // to print node lists
             std::cout << std::endl;
             count += 1;

--- a/src/CenGraph.cpp
+++ b/src/CenGraph.cpp
@@ -245,7 +245,7 @@ vector<double> Graph::betweennessCentrality(const Scope scope = Scope::FULL, con
         while(!S.empty()) {
             w = S.top();
             S.pop();
-            for(int j = 0; j < (signed)P[w].size(); j++) {
+            for(size_t j = 0; j < P[w].size(); j++) {
                 v = P[w][j];
                 delta[v] += ((double) sp[v] / (double) sp[w])*(1.0 + delta[w]);
             }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -946,18 +946,18 @@ int Graph::sccCount() {
 
 // write binary adjacency list to file
 void Graph::writeBinaryAdjacencyList(const Scope scope = Scope::FULL, string filename = "") {
-    FILE* myFile;
-    myFile = fopen(filename.c_str(), "wb");
+    FILE *const myFile = fopen(filename.c_str(), "wb");
 
 	for(int i=0; i<n; i++) {
         if(inScope(i, scope)) {
-			for(int j=0; j<(signed)E[i].size(); j++)
+			for(size_t j=0; j<E[i].size(); j++)
                 if(inScope(E[i][j], scope)) {
 					nodeidtype x = revMapNode(E[i][j]);
 					fwrite(&x,sizeof(int),1,myFile);
 				}
 		}
 	}
+
 	fclose(myFile);
 } // writeBinaryAdjacencyList
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main(const int argc, const char* argv[]) { Graph G; return listener(G); }
 int main(const int argc, const char* argv[]) {
 
     // catch no input graph given in command line parameter
-    if(argc < 2) {
+    if(argc != 2) {
         cerr << "Error: first argument should be the network filename." << endl;
         return 1;
     }
@@ -42,7 +42,7 @@ int main(const int argc, const char* argv[]) {
 
     // show some statistics of the network
     stats(G); // from examples.cpp
-	//computeIntensiveStats(G); // from examples.cpp; 
+	//computeIntensiveStats(G); // from examples.cpp;
     T.click();
 
     // compute the diameter of the largest WCC of this network
@@ -60,7 +60,7 @@ int main(const int argc, const char* argv[]) {
 	// list some statistics related to clustering coefficients
 	//clusteringStats(G); // from examples.cpp
 	//T.click();
-	
+
     return 0;
 }
 


### PR DESCRIPTION
This PR fixes some for loops so that they iterate using `size_t` instead of `int`, to match the return type of `vector::size()`. This would ease a transition towards having graphs with more than 2,147,483,647 elements.

In `printList` the min/max search is initiated by choosing the first element of the array as the initial value. This means that sentinel values are no longer needed.

Some trailing whitespace is dropped and a stronger check is made on input arguments to the main teexgraph binary.

